### PR TITLE
Remove cuda specific code in synthesis to run FastSpeech model on CPU(if CUDA is not available)

### DIFF
--- a/Audio/stft.py
+++ b/Audio/stft.py
@@ -11,6 +11,8 @@ from Audio.audio_processing import dynamic_range_compression
 from Audio.audio_processing import dynamic_range_decompression
 from Audio.audio_processing import window_sumsquare
 
+use_cuda = torch.cuda.is_available()
+device = torch.device('cuda' if use_cuda else 'cpu')
 
 class STFT(torch.nn.Module):
     """adapted from Prem Seetharaman's https://github.com/pseeth/pytorch-stft"""
@@ -63,8 +65,8 @@ class STFT(torch.nn.Module):
         input_data = input_data.squeeze(1)
 
         forward_transform = F.conv1d(
-            input_data.cuda(),
-            Variable(self.forward_basis, requires_grad=False).cuda(),
+            input_data.to(device),
+            Variable(self.forward_basis, requires_grad=False).to(device),
             stride=self.hop_length,
             padding=0).cpu()
 
@@ -98,7 +100,7 @@ class STFT(torch.nn.Module):
                 np.where(window_sum > tiny(window_sum))[0])
             window_sum = torch.autograd.Variable(
                 torch.from_numpy(window_sum), requires_grad=False)
-            window_sum = window_sum.cuda() if magnitude.is_cuda else window_sum
+            window_sum = window_sum.to(device) if magnitude.is_cuda else window_sum
             inverse_transform[:, :,
                               approx_nonzero_indices] /= window_sum[approx_nonzero_indices]
 

--- a/glow.py
+++ b/glow.py
@@ -29,6 +29,8 @@ import torch
 from torch.autograd import Variable
 import torch.nn.functional as F
 
+use_cuda = torch.cuda.is_available()
+device = torch.device('cuda' if use_cuda else 'cpu') 
 
 @torch.jit.script
 def fused_add_tanh_sigmoid_multiply(input_a, input_b, n_channels):
@@ -261,14 +263,19 @@ class WaveGlow(torch.nn.Module):
         spect = spect.unfold(2, self.n_group, self.n_group).permute(0, 2, 1, 3)
         spect = spect.contiguous().view(spect.size(0), spect.size(1), -1).permute(0, 2, 1)
 
-        if spect.type() == 'torch.cuda.HalfTensor':
-            audio = torch.cuda.HalfTensor(spect.size(0),
-                                          self.n_remaining_channels,
-                                          spect.size(2)).normal_()
+        if use_cuda:
+            if spect.type() == 'torch.cuda.HalfTensor':
+                audio = torch.cuda.HalfTensor(spect.size(0),
+                                              self.n_remaining_channels,
+                                              spect.size(2)).normal_()
+            else:
+                audio = torch.cuda.FloatTensor(spect.size(0),
+                                               self.n_remaining_channels,
+                                               spect.size(2)).normal_()
         else:
-            audio = torch.cuda.FloatTensor(spect.size(0),
-                                           self.n_remaining_channels,
-                                           spect.size(2)).normal_()
+            audio = torch.FloatTensor(spect.size(0),
+                                      self.n_remaining_channels,
+                                      spect.size(2)).normal_()
 
         audio = torch.autograd.Variable(sigma*audio)
 
@@ -286,12 +293,17 @@ class WaveGlow(torch.nn.Module):
             audio = self.convinv[k](audio, reverse=True)
 
             if k % self.n_early_every == 0 and k > 0:
-                if spect.type() == 'torch.cuda.HalfTensor':
-                    z = torch.cuda.HalfTensor(spect.size(
-                        0), self.n_early_size, spect.size(2)).normal_()
+                if use_cuda:
+                    if spect.type() == 'torch.cuda.HalfTensor':
+                        z = torch.cuda.HalfTensor(spect.size(
+                            0), self.n_early_size, spect.size(2)).normal_()
+                    else:
+                        z = torch.cuda.FloatTensor(spect.size(
+                            0), self.n_early_size, spect.size(2)).normal_()
                 else:
-                    z = torch.cuda.FloatTensor(spect.size(
+                    z = torch.FloatTensor(spect.size(
                         0), self.n_early_size, spect.size(2)).normal_()
+
                 audio = torch.cat((sigma*z, audio), 1)
 
         audio = audio.permute(0, 2, 1).contiguous().view(

--- a/synthesis.py
+++ b/synthesis.py
@@ -21,7 +21,7 @@ def get_FastSpeech(num):
     checkpoint_path = "checkpoint_" + str(num) + ".pth.tar"
     model = nn.DataParallel(FastSpeech()).to(device)
     model.load_state_dict(torch.load(os.path.join(
-        hp.checkpoint_path, checkpoint_path))['model'])
+        hp.checkpoint_path, checkpoint_path), map_location=device)['model'])
     model.eval()
 
     return model
@@ -35,9 +35,9 @@ def synthesis(model, text, alpha=1.0):
     src_pos = np.stack([src_pos])
     with torch.no_grad():
         sequence = torch.autograd.Variable(
-            torch.from_numpy(text)).cuda().long()
+            torch.from_numpy(text)).to(device).long()
         src_pos = torch.autograd.Variable(
-            torch.from_numpy(src_pos)).cuda().long()
+            torch.from_numpy(src_pos)).to(device).long()
 
         mel, mel_postnet = model.module.forward(sequence, src_pos, alpha=alpha)
 
@@ -69,6 +69,6 @@ if __name__ == "__main__":
     tacotron2 = utils.get_Tacotron2()
     mel_tac2, _, _ = utils.load_data_from_tacotron2(words, tacotron2)
     waveglow.inference.inference(torch.stack([torch.from_numpy(
-        mel_tac2).cuda()]), wave_glow, os.path.join("results", "tacotron2.wav"))
+        mel_tac2).to(device)]), wave_glow, os.path.join("results", "tacotron2.wav"))
 
     utils.plot_data([mel.numpy(), mel_postnet.numpy(), mel_tac2])


### PR DESCRIPTION
Thanks for the FastSpeech implementation!

Sometimes people may want to synthesize voice on CPU, so this simple PR enables running FastSpeech on CPU if CUDA is not available on the system.

Synthesized wav seems mostly identical to GPU.

Tested with `conda install pytorch torchvision cpuonly -c pytorch` (pytorch version 1.3.1 + python 3.7 + Ubuntu 18.04)